### PR TITLE
Add new ML-related job

### DIFF
--- a/conf/sync-jobs.json
+++ b/conf/sync-jobs.json
@@ -254,6 +254,13 @@
         "children": []
       },
       {
+        "name": "Update Predictions with Return dates",
+        "procedure": "CALL etl.add_observed_appointments_to_ml_predictions_v1_0();",
+        "priority": 29,
+        "isEnabled": true,
+        "children": []
+      },
+      {
         "name": "Update Prediction Model's Baseline Visits",
         "procedure": "CALL predictions.generate_flat_ml_baseline_visit();",
         "priority": 30,


### PR DESCRIPTION
Adds a job the updates the `observed_rtc_date` field in the `ml_weekly_predictions` table, based on the date when the patient returns to care (depends on updates to HIV Summary table).